### PR TITLE
Export components from plugin

### DIFF
--- a/packages/gatsby-plugin-support-chat/package.json
+++ b/packages/gatsby-plugin-support-chat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-support-chat",
   "version": "0.0.1",
-  "main": "index.js",
+  "main": "src/index.js",
   "license": "MIT",
   "devDependencies": {
     "gatsby": "^3.5.0",

--- a/packages/gatsby-plugin-support-chat/src/index.js
+++ b/packages/gatsby-plugin-support-chat/src/index.js
@@ -1,0 +1,2 @@
+export { default as SupportChat } from "./components/widget"
+export { useSupportChat } from "./components/hooks"


### PR DESCRIPTION
This allows users to import the component or hook instead of configuring as a plugin